### PR TITLE
Fix Enchanting Infuser for Fabric 26.1

### DIFF
--- a/fabric/src/main/java/io/github/fourmisain/taxfreelevels/fabric/mixin/EnchantingInfuserMixin.java
+++ b/fabric/src/main/java/io/github/fourmisain/taxfreelevels/fabric/mixin/EnchantingInfuserMixin.java
@@ -9,7 +9,7 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.ModifyArg;
 
 @Pseudo
-@Mixin(targets = "fuzs.enchantinginfuser.world.inventory.InfuserMenu")
+@Mixin(targets = "fuzs.enchantinginfuser.common.world.inventory.InfuserMenu")
 public abstract class EnchantingInfuserMixin {
 	@ModifyArg(
 		method = "*",


### PR DESCRIPTION
The path in the latest version of the mod is different then what TFL mixins target